### PR TITLE
Stream S3 zip downloads to reduce memory usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		        <dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>2.20.28</version> <!-- Use the latest version -->
@@ -150,6 +150,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb-enhanced</artifactId>
             <version>2.20.28</version> <!-- Use the latest version -->
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.20.28</version>
         </dependency>
 		<!-- <dependency>
   <groupId>org.springframework.ai</groupId>

--- a/src/main/java/com/example/config/S3Config.java
+++ b/src/main/java/com/example/config/S3Config.java
@@ -1,0 +1,47 @@
+package com.example.config;
+
+import java.net.URI;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+@Configuration
+@EnableConfigurationProperties(S3Properties.class)
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(S3Properties properties) {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(properties.getRegion()));
+
+        if (StringUtils.hasText(properties.getEndpoint())) {
+            builder = builder.endpointOverride(URI.create(properties.getEndpoint()))
+                    .forcePathStyle(true);
+        }
+
+        builder = builder.credentialsProvider(resolveCredentialsProvider(properties));
+
+        return builder.build();
+    }
+
+    private AwsCredentialsProvider resolveCredentialsProvider(S3Properties properties) {
+        boolean hasAccessKey = StringUtils.hasText(properties.getAccessKeyId());
+        boolean hasSecretKey = StringUtils.hasText(properties.getSecretAccessKey());
+
+        if (hasAccessKey && hasSecretKey) {
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.getAccessKeyId(), properties.getSecretAccessKey()));
+        }
+
+        return DefaultCredentialsProvider.create();
+    }
+}

--- a/src/main/java/com/example/config/S3Properties.java
+++ b/src/main/java/com/example/config/S3Properties.java
@@ -1,0 +1,53 @@
+package com.example.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public class S3Properties {
+
+    private String region;
+    private String bucket;
+    private String accessKeyId;
+    private String secretAccessKey;
+    private String endpoint;
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public void setAccessKeyId(String accessKeyId) {
+        this.accessKeyId = accessKeyId;
+    }
+
+    public String getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    public void setSecretAccessKey(String secretAccessKey) {
+        this.secretAccessKey = secretAccessKey;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/src/main/java/com/example/controller/S3ZipDownloadController.java
+++ b/src/main/java/com/example/controller/S3ZipDownloadController.java
@@ -1,0 +1,58 @@
+package com.example.controller;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import com.example.entity.s3.S3ZipDownloadRequest;
+import com.example.service.S3ZipDownloadService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/s3")
+@Validated
+public class S3ZipDownloadController {
+
+    private static final String DEFAULT_ARCHIVE_NAME = "archive.zip";
+
+    private final S3ZipDownloadService s3ZipDownloadService;
+
+    public S3ZipDownloadController(S3ZipDownloadService s3ZipDownloadService) {
+        this.s3ZipDownloadService = s3ZipDownloadService;
+    }
+
+    @PostMapping("/zip")
+    public ResponseEntity<StreamingResponseBody> downloadAsZip(@Valid @RequestBody S3ZipDownloadRequest request) {
+        List<String> keys = request.getObjectKeys();
+
+        // StreamingResponseBody を利用してレスポンスを逐次書き込み、大量ファイルでもメモリフットプリントを抑える。
+        StreamingResponseBody responseBody = outputStream -> s3ZipDownloadService.streamObjectsAsZip(keys, outputStream);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/zip"));
+        headers.setContentDisposition(createContentDisposition(request.getArchiveFileName()));
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(responseBody);
+    }
+
+    private ContentDisposition createContentDisposition(String requestedName) {
+        String fileName = StringUtils.hasText(requestedName) ? requestedName : DEFAULT_ARCHIVE_NAME;
+        return ContentDisposition.attachment()
+                .filename(fileName, StandardCharsets.UTF_8)
+                .build();
+    }
+}

--- a/src/main/java/com/example/entity/s3/S3ZipDownloadRequest.java
+++ b/src/main/java/com/example/entity/s3/S3ZipDownloadRequest.java
@@ -1,0 +1,31 @@
+package com.example.entity.s3;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public class S3ZipDownloadRequest {
+
+    // まとめて取得する S3 オブジェクトキーのリスト。空リクエストはバリデーションで弾く。
+    @NotEmpty
+    private List<String> objectKeys;
+
+    // ダウンロード時の ZIP ファイル名（任意指定）。
+    private String archiveFileName;
+
+    public List<String> getObjectKeys() {
+        return objectKeys;
+    }
+
+    public void setObjectKeys(List<String> objectKeys) {
+        this.objectKeys = objectKeys;
+    }
+
+    public String getArchiveFileName() {
+        return archiveFileName;
+    }
+
+    public void setArchiveFileName(String archiveFileName) {
+        this.archiveFileName = archiveFileName;
+    }
+}

--- a/src/main/java/com/example/service/S3ZipDownloadService.java
+++ b/src/main/java/com/example/service/S3ZipDownloadService.java
@@ -1,0 +1,101 @@
+package com.example.service;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.example.config.S3Properties;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@Service
+public class S3ZipDownloadService {
+
+    private static final int DEFAULT_BUFFER_SIZE = 16 * 1024;
+
+    private final S3Client s3Client;
+    private final S3Properties properties;
+
+    public S3ZipDownloadService(S3Client s3Client, S3Properties properties) {
+        this.s3Client = s3Client;
+        this.properties = properties;
+    }
+
+    public void streamObjectsAsZip(List<String> objectKeys, OutputStream outputStream) {
+        if (objectKeys == null || objectKeys.isEmpty()) {
+            throw new IllegalArgumentException("objectKeys must not be null or empty");
+        }
+
+        if (!StringUtils.hasText(properties.getBucket())) {
+            throw new IllegalStateException("S3 bucket name is not configured");
+        }
+
+        // ここでレスポンスの OutputStream を ZIP 用にラップし、逐次的に書き込むことで
+        // 大容量ファイルでもメモリ消費を抑えたストリーミング処理にしている。
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new BufferedOutputStream(outputStream))) {
+            byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+
+            for (String key : objectKeys) {
+                if (!StringUtils.hasText(key)) {
+                    throw new IllegalArgumentException("object key must not be blank");
+                }
+
+                writeObjectToZip(zipOutputStream, buffer, key.trim());
+            }
+
+            // finish を呼び出して ZIP のフッタを書き込み、クライアント側で解凍できるようにする。
+            zipOutputStream.finish();
+            zipOutputStream.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to stream zip archive", e);
+        }
+    }
+
+    private void writeObjectToZip(ZipOutputStream zipOutputStream, byte[] buffer, String key) {
+        // ZIP 内の 1 エントリを生成しつつ、S3 からのレスポンスを逐次読み取って書き込む。
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(properties.getBucket())
+                .key(key)
+                .build();
+
+        boolean entryStarted = false;
+
+        try (ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request)) {
+            ZipEntry zipEntry = new ZipEntry(key);
+            zipOutputStream.putNextEntry(zipEntry);
+            entryStarted = true;
+
+            int read;
+            while ((read = response.read(buffer)) != -1) {
+                // S3 から読み込んだチャンクを即座に ZIP に書き出し、ダウンロードをストリーム処理する。
+                zipOutputStream.write(buffer, 0, read);
+            }
+        } catch (NoSuchKeyException e) {
+            throw new IllegalArgumentException("Object not found in S3: " + key, e);
+        } catch (SdkClientException e) {
+            throw new IllegalStateException("Failed to download object from S3: " + key, e);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write object to zip: " + key, e);
+        } finally {
+            if (entryStarted) {
+                try {
+                    zipOutputStream.closeEntry();
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to close zip entry for object: " + key, e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,11 @@ logging:
   level:
     root: INFO
     com.example: DEBUG
+
+aws:
+  s3:
+    bucket: ${AWS_S3_BUCKET:}
+    region: ${AWS_REGION:ap-northeast-1}
+    access-key-id: ${AWS_ACCESS_KEY_ID:}
+    secret-access-key: ${AWS_SECRET_ACCESS_KEY:}
+    endpoint: ${AWS_S3_ENDPOINT:}


### PR DESCRIPTION
## Summary
- stream S3 objects directly into the HTTP response using StreamingResponseBody
- adjust the zip service to write entries sequentially without buffering the entire archive
- document request fields and streaming behaviour with inline comments

## Testing
- `mvn -q -DskipTests compile` *(fails: parent POM download blocked by repository access restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691454c87ba48327b43e3039202a0ddb)