### PR TITLE
feat: add Swagger UI and OpenAPI spec generation via springdoc-openapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,11 +120,6 @@
 			<artifactId>jquery</artifactId>
 			<version>3.5.1</version>
 		</dependency>
-		<!-- <dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency> -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
@@ -144,29 +139,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
-            <version>2.20.28</version> <!-- Use the latest version -->
+            <version>2.20.28</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb-enhanced</artifactId>
-            <version>2.20.28</version> <!-- Use the latest version -->
+            <version>2.20.28</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
             <version>2.20.28</version>
         </dependency>
-		<!-- <dependency>
-  <groupId>org.springframework.ai</groupId>
-  <artifactId>spring-ai-client-chat</artifactId>
-  <version>1.0.0</version>
-</dependency> -->
-		<!-- <dependency>
-  <groupId>org.springframework.ai</groupId>
-  <artifactId>spring-ai-openai</artifactId>
-  <version>1.0.0</version>
-</dependency> -->
-<!-- https://mvnrepository.com/artifact/org.springframework.ai/spring-ai-openai-spring-boot-starter -->
 <dependency>
     <groupId>org.springframework.ai</groupId>
     <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
@@ -178,25 +162,18 @@
   <version>9.1.1</version>
 </dependency>
 
-		<!-- <dependency>
-    		<groupId>org.springframework.data</groupId>
-    		<artifactId>spring-data-jpa</artifactId>
-  		</dependency> -->
-  		<!-- <dependency>
-			<groupId>com.github.pagehelper</groupId>
-			<artifactId>pagehelper-spring-boot-starter</artifactId>
-			<version>1.3.0</version>
-		</dependency> -->
-		<!--<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency> -->
-  <dependency>
-    <groupId>com.example.backend</groupId>
-    <artifactId>backend-spring-common</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-</dependency>
+  		<dependency>
+    		<groupId>com.example.backend</groupId>
+    		<artifactId>backend-spring-common</artifactId>
+    		<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+
+		<!-- Swagger UI + OpenAPI スペック自動生成 -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
 	</dependencies>
 
 

--- a/src/main/java/com/example/config/OpenApiConfig.java
+++ b/src/main/java/com/example/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.example.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Backend Spring API")
+                        .version("1.0.0")
+                        .description("Spring Boot アプリケーション API ドキュメント"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+}

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -13,29 +13,30 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.formLogin(login -> login. // フォーム認証の設定記述開始
-				loginProcessingUrl("/login") // ユーザ名・パスワードの送信先URL
-				.loginPage("/login") // ログイン画面のURL
-				.defaultSuccessUrl("/home") // ログイン成功後のリダイレクト先URL
-				.failureUrl("/login?error") // ログイン失敗後のリダイレクト先URL
-				.permitAll()) // ログイン画面は未ログインでもアクセス可能
-				.logout(logout -> logout // ログアウトの設定記述開始
+		http.formLogin(login -> login
+				.loginProcessingUrl("/login")
+				.loginPage("/login")
+				.defaultSuccessUrl("/home")
+				.failureUrl("/login?error")
+				.permitAll())
+				.logout(logout -> logout
 						.logoutSuccessUrl("/")
-						.invalidateHttpSession(true)
-
-				) // ログアウト成功後のリダイレク先URL
+						.invalidateHttpSession(true))
 				.authorizeHttpRequests(
-						authz -> authz.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+						authz -> authz
+								.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 								.requestMatchers("/").permitAll()
 								.requestMatchers("/api/anime").permitAll()
 								.requestMatchers("/characterComment/next-sequence").permitAll()
 								.requestMatchers("/characterComment/**").permitAll()
 								.requestMatchers("/chat/**").permitAll()
+								// Swagger UI ・ OpenAPI
+								.requestMatchers("/swagger-ui.html").permitAll()
+								.requestMatchers("/swagger-ui/**").permitAll()
+								.requestMatchers("/v3/api-docs/**").permitAll()
 								.requestMatchers("/general").hasRole("GENERAL")
 								.requestMatchers("/admin").hasRole("ADMIN")
-				.anyRequest().authenticated());
-
-		;
+								.anyRequest().authenticated());
 
 		return http.build();
 	}
@@ -44,5 +45,4 @@ public class SecurityConfig {
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
-
 }

--- a/src/main/java/com/example/controller/AnimeController.java
+++ b/src/main/java/com/example/controller/AnimeController.java
@@ -1,44 +1,34 @@
 package com.example.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-// import dev.itboot.mb.service.AnnictService;
 
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import org.springframework.stereotype.Controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Tag(name = "Anime", description = "アニメ一覧 API")
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "http://localhost:5173") // フロントエンドのURLを指定
+@CrossOrigin(origins = "http://localhost:5173")
 public class AnimeController {
 
     private static final Logger logger = LoggerFactory.getLogger(AnimeController.class);
 
-    // private final AnnictService annictService;
-
-    // public AnimeController(AnnictService annictService) {
-    //     this.annictService = annictService;
-    // }
-
+    @Operation(summary = "アニメ一覧取得", description = "登録されているアニメの一覧を返します")
     @GetMapping("/anime")
     public List<Map<String, String>> getAnimeList() {
         logger.info("GET /api/anime called");
         return Arrays.asList(
             Map.of("id", "1", "title", "進撃の巨人", "year", "2013"),
             Map.of("id", "2", "title", "鬼滅の刃", "year", "2019"),
-            Map.of("id", "3", "title", "呪術廻戦", "year", "2020")
+            Map.of("id", "3", "title", "咒術回戦", "year", "2020")
         );
     }
-
-    // @GetMapping("/annict/works")
-    // public Mono<String> getWorks() {
-    //     return annictService.fetchWorks();
-    // }
-
 }

--- a/src/main/java/com/example/controller/CharacterCommentController.java
+++ b/src/main/java/com/example/controller/CharacterCommentController.java
@@ -2,7 +2,8 @@ package com.example.controller;
 
 import com.example.domain.CharacterComment;
 import com.example.service.CharacterCommentService;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.slf4j.Logger;
@@ -17,35 +18,30 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-/**
- * CharacterCommentController
- * キャラクターに対するコメント投稿API
- * @author 
- */
+@Tag(name = "CharacterComment", description = "キャラクターコメント API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/characterComment")
-@CrossOrigin(origins = "*") // CORS設定
+@CrossOrigin(origins = "*")
 public class CharacterCommentController {
 
     private static final Logger logger = LoggerFactory.getLogger(CharacterCommentController.class);
-    
-    // DI
+
     private final CharacterCommentService service;
 
-    // キャラクターIDでコメントリスト取得
+    @Operation(summary = "キャラクター別コメント取得", description = "指定したキャラクター ID のコメント一覧を返します")
     @GetMapping("/all/{characterId}")
     public List<CharacterComment> getByCharacter(@PathVariable String characterId) {
         return service.selectByCharacterId(characterId);
     }
 
-    // コメント全件取得
+    @Operation(summary = "全コメント取得", description = "全キャラクターのコメント一覧を返します")
     @GetMapping("/all")
     public List<CharacterComment> getAllComments() {
         return service.selectAll();
     }
 
-    // コメントCSV出力
+    @Operation(summary = "コメント CSV エクスポート", description = "全コメントを CSV ファイルとしてダウンロードします")
     @GetMapping(value = "/export", produces = "text/csv")
     public ResponseEntity<InputStreamResource> exportCommentsCsv() {
         List<CharacterComment> comments = service.selectAll();
@@ -86,23 +82,18 @@ public class CharacterCommentController {
         return escaped;
     }
 
-    // コメントの追加、編集
-	@PostMapping("/process")
-	public ResponseEntity<?> process(@RequestBody CharacterComment comment) {
-		System.out.println("保存コントローラ、コンソールログだよ");
-		logger.info("保存コントローラデバッグだよ");
+    @Operation(summary = "コメント追加・更新", description = "コメントを新規登録または更新します")
+    @PostMapping("/process")
+    public ResponseEntity<?> process(@RequestBody CharacterComment comment) {
+        logger.info("保存コントローラデバッグだよ");
+        service.save(comment);
+        return ResponseEntity.ok("Saved successfully");
+    }
 
-		service.save(comment);
-		return ResponseEntity.ok("Saved successfully");
-	}
-    
-
-    // コメント削除
-	@DeleteMapping("/delete/{id}")
-	public ResponseEntity<?> deleteTeacher(@PathVariable Long id) {
-		service.deleteByPrimaryKey(id);
-		return ResponseEntity.ok("Deleted successfully");
-
-	}
+    @Operation(summary = "コメント削除", description = "指定した ID のコメントを削除します")
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<?> deleteTeacher(@PathVariable Long id) {
+        service.deleteByPrimaryKey(id);
+        return ResponseEntity.ok("Deleted successfully");
+    }
 }
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,20 @@ aws:
     access-key-id: ${AWS_ACCESS_KEY_ID:}
     secret-access-key: ${AWS_SECRET_ACCESS_KEY:}
     endpoint: ${AWS_S3_ENDPOINT:}
+
+# ============================================
+# Swagger UI / OpenAPI
+# アクセス: http://localhost:8080/swagger-ui.html
+# JSON スペック: http://localhost:8080/v3/api-docs
+# ============================================
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true
+  api-docs:
+    path: /v3/api-docs
+  packages-to-scan: com.example.controller
+  # 本番環境では false にすることを推奨（環境別 yml で上書き）
+  show-actuator: false


### PR DESCRIPTION
- pom.xml: springdoc-openapi-starter-webmvc-ui 2.6.0 を追加
- OpenApiConfig.java: API 基本情報・Bearer 認証スキーム定義
- SecurityConfig.java: /swagger-ui/** /v3/api-docs/** を permitAll に追加
- application.yml: springdoc 設定を追加
- AnimeController, CharacterCommentController: @Tag/@Operation アノテーション追加